### PR TITLE
Default to preview mode off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datatable-translatable",
-  "version": "0.11.15",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "A Component Library for Translating DataTables using React and MaterialUI.",
   "homepage": "https://datatable-translatable.netlify.com/",

--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -58,7 +58,7 @@ function DataTable({
   } = config;
   const dataTableElement = useRef();
   const [rowsPerPage, setRowsPerPage] = useState(options.rowsPerPage || 25);
-  const [preview, setPreview] = useState(true);
+  const [preview, setPreview] = useState(false);
   const [columnsShow, setColumnsShow] = useState(columnsShowDefault);
   const [isAutoSaveChanged, setIsAutoSaveChanged] = useState(false);
 

--- a/src/components/toolbar/Toolbar.js
+++ b/src/components/toolbar/Toolbar.js
@@ -35,7 +35,7 @@ function Toolbar({
       }
       <Tooltip title="Preview">
         <IconButton className={classes.iconButton} onClick={onPreview} aria-label="Preview" data-test="preview-icon">
-          {preview ? <PageviewOutlined /> : <Pageview />}
+          {preview ? <Pageview /> : <PageviewOutlined /> }
         </IconButton>
       </Tooltip>
       <Tooltip title="Save">


### PR DESCRIPTION
Partner PR to https://github.com/unfoldingWord/markdown-translatable/pull/86

Closes unfoldingWord/tc-create-app#1128
Closes unfoldingWord/tc-create-app#1127

Sets initial state of preview to off.
Also ensure the correct icon is used to indicate if preview is enabled. 