### PR TITLE
Verified use of Unicode 00A0 in empty fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datatable-translatable",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "description": "A Component Library for Translating DataTables using React and MaterialUI.",
   "homepage": "https://datatable-translatable.netlify.com/",

--- a/src/components/cell/Cell.js
+++ b/src/components/cell/Cell.js
@@ -37,7 +37,7 @@ function BlockEditableWrapper({
     </Typography>
   );
   const originalValue = original || '*empty*';
-  const translationValue = translation || '';
+  const translationValue = translation || '\u00A0';
 
   return (
     <div className={classes.row}>
@@ -143,8 +143,9 @@ function Cell(props) {
   const [original, translation] = value.split(delimiters.cell);
 
   function handleEdit(markdown){
+    const _markdown = markdown.replace(/^\u00A0/,'');
     onEdit({
-      rowIndex, columnIndex: columnIndex - 1, value: markdown,
+      rowIndex, columnIndex: columnIndex - 1, value: _markdown,
     });
   };
 


### PR DESCRIPTION
Tested in tc-create, both en_tn and en_twl TSV files.

In both"
- if no edits were done, then the u00A0 was not saved in user branch.
- if edits were made then the u00A0 character was removed from the beginning if present

Note: the Unicode 00A0 character is the No Break Space character or the entity