### PR TITLE
Allow changing values of new row fields

### DIFF
--- a/src/components/actions-menu/AddRow.js
+++ b/src/components/actions-menu/AddRow.js
@@ -8,7 +8,6 @@ import {
   DialogTitle,
   DialogActions,
   DialogContent,
-  DialogContentText,
   TextField,
 } from '@material-ui/core';
 import {
@@ -71,14 +70,22 @@ function AddRowMenu({
       } else {
         // by default...
         text = (
-          <DialogContentText key={name + i}>
-            <strong>{name}:</strong>
-            {' ' + newRow[i]}
-          </DialogContentText>
+          <TextField
+            key={i}
+            defaultValue={newRow[i]}
+            label={name}
+            margin="normal"
+            onChange={(event) => {
+              newRow[i] = event.target.value;
+            }}
+            fullWidth
+          />
         );
+
         if ( state.columnsFilterOptions[i] && state.columnsFilterOptions[i].length > 0 ) {
           text = (
             <Autocomplete
+              key={i}
               options={state.columnsFilterOptions[i]}
               value={newRow[i]}
               onChange={(event, newValue) => {
@@ -87,7 +94,7 @@ function AddRowMenu({
               onInputChange={(event, newValue) => {
                 newRow[i] = newValue;
               }}
-              renderInput={(params) => <TextField {...params} label={state.columnNames[i]} margin="normal" />}
+              renderInput={(params) => <TextField {...params} label={name} margin="normal" />}
               freeSolo={true}
             />
           );


### PR DESCRIPTION
https://github.com/unfoldingword/tc-create-app/issues/1166

Allows editing fields before row is added. Used MUI fullwidth TextField which is a little different from mock but probably desired to keep consistency with other areas. 
![image](https://user-images.githubusercontent.com/1534605/172304776-b552d888-29f1-4650-9867-c583f0937ac6.png)
