### PR TITLE
bump version again and fix lifecycle script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datatable-translatable",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "license": "MIT",
   "description": "A Component Library for Translating DataTables using React and MaterialUI.",
   "homepage": "https://datatable-translatable.netlify.com/",
@@ -15,7 +15,7 @@
     "build": "styleguidist build",
     "deploy": "sleep 2 && git push",
     "test": "jest __tests__ && cat ./coverage/lcov.info | coveralls",
-    "prepublishOnly": "rm -fr ./dist & babel ./src --out-dir ./dist -s inline"
+    "prepack": "rm -fr ./dist & babel ./src --out-dir ./dist -s inline"
   },
   "keywords": [
     "tsv",


### PR DESCRIPTION
I use `yarn publish` to release v 1.0.5 and it did not pick up changes because babel did not compile the files to dist. Apparently the prepublishOnly lifecycle event is not triggered by yarn. See https://github.com/yarnpkg/berry/issues/2305 Apparently according to https://yarnpkg.com/advanced/lifecycle-scripts prepack is the correct lifecycle event to use. 