### PR TITLE
Fix scroll issue with reference drop down

### DIFF
--- a/src/components/datatable/muiTheme.js
+++ b/src/components/datatable/muiTheme.js
@@ -14,6 +14,7 @@ export const getMuiTheme = createMuiTheme({
         // '&:first-child': { top:'0 !important' },
         '&:nth-child(1)': {
           position: 'sticky',
+          zIndex: 15,
           top: '48px',
           background: 'white',
         },


### PR DESCRIPTION
Fixes https://github.com/unfoldingWord/tc-create-app/issues/1311

The new dropdown have a relative position which made them appear on top of the sticky header. 
The way to fix this is just to give a z-index to the header. It could have been anything grater than 0 so I chose 15.
