### PR TITLE
Do not add nbsp to autocompleter

### DIFF
--- a/src/components/cell/Cell.js
+++ b/src/components/cell/Cell.js
@@ -40,7 +40,6 @@ function BlockEditableWrapper({
     </Typography>
   );
   const originalValue = original || '*empty*';
-  const translationValue = translation || '\u00A0';
   const { actions } = useContext(MarkdownContext);
 
   return (
@@ -73,24 +72,26 @@ function BlockEditableWrapper({
             <div data-test={'id_'+dataTestId+'_'+columnData.name+'_content'} className="editableWrapper">
               { columnsFilterOptions && columnsFilterOptions[columnIndex-1] && columnsFilterOptions[columnIndex-1].length > 0 ?
                 <Autocomplete
-                  value={translationValue}
+                  value={translation}
                   options={columnsFilterOptions[columnIndex-1]}
                   freeSolo
                   onChange={(event, newValue) => {
                     if (typeof newValue === 'string' ) {
                       handleEdit(newValue);
+
                       if (actions && actions.setIsChanged) {
                         actions.setIsChanged(true);
-                      }                  
+                      }
                     }
                   }}
                   handleHomeEndKeys
                   renderInput={(params) => <TextField {...params} onBlur={(event) => {
                     if ( event ) {
                       handleEdit(event.target.value);
+
                       if (actions && actions.setIsChanged) {
                         actions.setIsChanged(true);
-                      }                  
+                      }
                     }
                   } }
                   />
@@ -101,7 +102,7 @@ function BlockEditableWrapper({
                   key={`${rowIndex}-${columnIndex}-target`}
                   debounce={1000}
                   preview={preview}
-                  markdown={translationValue}
+                  markdown={translation || '\u00A0'}
                   editable={true}
                   inputFilters={inputFilters}
                   outputFilters={outputFilters}


### PR DESCRIPTION
fixes https://github.com/unfoldingWord/tc-create-app/issues/1323

When autocompleter has no existing value it defaults to &nbsp; but in unicode. This makes a hidden space so autocompleting will not finish anything typed because it will all start with \u00A0 which does not match anything unless user presses backspace first.

Test:
1. start styleguidist.
2. start typing anything in first auto complete form. 'figs', 'tr' etc. Options to select should be shown.

Requesting review from @mandolyte because you added the \u00A0 to begin with. 