### PR TITLE
Fix crash clearing autocompleter when adding new row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datatable-translatable",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "MIT",
   "description": "A Component Library for Translating DataTables using React and MaterialUI.",
   "homepage": "https://datatable-translatable.netlify.com/",

--- a/src/components/actions-menu/AddRow.js
+++ b/src/components/actions-menu/AddRow.js
@@ -96,7 +96,7 @@ function AddRowMenu({
               options={state.columnsFilterOptions[i]}
               value={newRow[i]}
               onChange={(event, newValue) => {
-                newRow[i] = newValue;
+                newRow[i] = newValue === null ? '' : newValue;
               }}
               onInputChange={(event, newValue) => {
                 newRow[i] = newValue;


### PR DESCRIPTION
Fixes https://github.com/unfoldingWord/tc-create-app/issues/1320

src/core/datatable.js:150 expects all values to always be strings. It was crashing because clicking the 'x' icon on the autocompleter set the value to null. This change will ensure it becomes the empty string ''.

### Test
1. start stylguidist.
2. Scroll down to first row with supportReference.
3. Click '+' to add new row.
4. Click 'x' to clear supportReference on new row.
5. Click add row,
6. Row should be added with no errors 