### PR TITLE
Feature superdav42 1088 after search return to last clicked row

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -65,6 +65,7 @@ function DataTable({
   const [isAutoSaveChanged, setIsAutoSaveChanged] = useState(false);
   const [saveRowId, setSaveRowId] = React.useState('');
   const [pagination, setPagination] = React.useState(true);
+  const [searchClose, setSearchClose] = React.useState(false);
 
   const { state, actions } = useContext(DataTableContext);
   const {
@@ -135,11 +136,12 @@ function DataTable({
     setColumnsShow(_columnsShow);
   }, [columnsShow]);
 
-  const scrollToTop = useCallback((lastpage) => {
+  const scrollToTop = useCallback(() => {
+    console.log("sssssssssssssssssssss")
     window.scrollTo(0, 0);
-    // if (dataTableElement && dataTableElement.current) {
-    //   window.scrollTo(0, dataTableElement.current.tableRef.offsetParent.offsetTop);
-    // }
+    if (dataTableElement && dataTableElement.current) {
+      window.scrollTo(0, dataTableElement.current.tableRef.offsetParent.offsetTop);
+    }
   }, []);
 
   const onChangeRowsPerPage = useCallback(() => (rows) => {
@@ -182,7 +184,37 @@ function DataTable({
     [_onSave, markdownState.isChanged, preview, togglePreview, _onValidate, onValidate]
   );
 
-  const _options = useMemo(() => ({
+  useEffect(() => {
+    console.log("searchClose", searchClose, pagination, saveRowId )
+    if(searchClose){
+      if (saveRowId){
+        const element = document.getElementById(saveRowId);
+        if(element){
+          element.scrollIntoView()
+          console.log("ssssssssssss",element)
+        } else{
+          console.log("element not found", saveRowId)
+        }
+      }
+      // console.log()
+      setSearchClose(false)
+      
+      setTimeout(()=>{
+        setPagination(true);
+        console.log("setpagination-True")
+      }
+      ,5000)
+      
+    }
+    
+
+  }, [searchClose, saveRowId]);
+
+  useEffect(()=>{
+    console.log("pagination", pagination)
+  }), [pagination]
+
+  const _options = {
     pagination: pagination,
     responsive: 'scrollFullHeight',
     fixedHeaderOptions,
@@ -203,19 +235,9 @@ function DataTable({
       setPagination(false)
     },
     onSearchClose: () =>{
-      const testRefId = saveRowId;
-      console.log("onSearchClose() saveRowId:", saveRowId);
-      // dataTableElement.current.changePage(clickedPage);
-      if (testRefId){
-        const element = document.getElementById(testRefId);
-        if ( element ) {
-          element.scrollIntoView();
-        } else {
-          alert(`Element id not found: ${testRefId}`);
-        }
-        // setPagination(true);
-      }
+      setSearchClose(true) 
     },
+
     onRowClick: (rowData) => {
       const getRowData = rowData[1].props.tableMeta.rowData
       const [chapter] = getRowData[2].split(delimiters.cell);
@@ -231,7 +253,7 @@ function DataTable({
     print: false,
     customToolbar,
     ...options,
-  }), [pagination, customToolbar, onChangeRowsPerPage, onColumnViewChange, options, rowsPerPage, scrollToTop]);
+  } //), [pagination, customToolbar, onChangeRowsPerPage, onColumnViewChange, options, rowsPerPage, scrollToTop]);
 
   const _data = useMemo(() => getData({
     data, columnNames, rowHeader,

--- a/src/components/datatable/DataTable.md
+++ b/src/components/datatable/DataTable.md
@@ -6,6 +6,10 @@ import targetFile from "./mocks/ru_tn_57-TIT";
 function Component() {
   const [sourceFile, setSourceFile] = React.useState(_sourceFile);
   const [savedFile, setSavedFile] = React.useState(targetFile);
+  
+  const [pagination, setPagination] = React.useState(true);
+  const [saveRowId, setSaveRowId] = React.useState('');
+
 
   //Uncomment this to test a page change from a new source file
   // setTimeout(() => {
@@ -15,10 +19,49 @@ function Component() {
   const delimiters = { row: "\n", cell: "\t" };
 
   const options = {
+    pagination: pagination,
     page: 0,
     rowsPerPage: 10,
     rowsPerPageOptions: [10, 25, 50, 100],
+    onRowClick: (rowData) => {
+      const getRowData = rowData[1].props.tableMeta.rowData
+      const [chapter] = getRowData[2].split(delimiters.cell);
+      const [verse] = getRowData[3].split(delimiters.cell);
+      const [uid] = getRowData[4].split(delimiters.cell);
+      const rowId = `header-${chapter}-${verse}-${uid}`;
+      setSaveRowId(rowId)
+    },
+
+    onSearchClose: () =>{
+      const testRefId = saveRowId;
+      const element = document.getElementById(testRefId);
+      if ( element ) {
+        element.scrollIntoView();
+      } else {
+        alert(`Element id not found: ${testRefId}`);
+      }
+    },
+
+    onFilterChipClose: () =>{
+      console.log('dsddddd')
+      const testRefId = saveRowId;
+      const element = document.getElementById(testRefId);
+      if ( element ) {
+        element.scrollIntoView();
+      } else {
+        alert(`Element id not found: ${testRefId}`);
+      }
+    },
+
+    onFilterDialogOpen:() =>{
+      setPagination(false)
+      
+    },
+    onSearchOpen:() =>{
+      setPagination(false)
+    },
   };
+  
 
   const rowHeader = (rowData, actionsMenu) => {
     const book = rowData[0].split(delimiters.cell).find((value) => value);
@@ -68,10 +111,12 @@ function Component() {
   };
 
   const generateRowId = (rowData) => {
+
     const [chapter] = rowData[2].split(delimiters.cell);
     const [verse] = rowData[3].split(delimiters.cell);
     const [uid] = rowData[4].split(delimiters.cell);
-    return `header-${chapter}-${verse}-${uid}`;
+    const rowId = `header-${chapter}-${verse}-${uid}`;
+    return rowId;
   };
 
   return (
@@ -110,6 +155,9 @@ function Component() {
   const [sourceFile, setSourceFile] = React.useState(_sourceFile);
   const [savedFile, setSavedFile] = React.useState(targetFile);
 
+  const [pagination, setPagination] = React.useState(true);
+  const [saveRowId, setSaveRowId] = React.useState('');
+
   //Uncomment this to test a page change from a new source file
   // setTimeout(() => {
   //   setSourceFile(targetFile);
@@ -118,9 +166,49 @@ function Component() {
   const delimiters = { row: "\n", cell: "\t" };
 
   const options = {
+    pagination: pagination,
     page: 0,
     rowsPerPage: 10,
     rowsPerPageOptions: [10, 25, 50, 100],
+    onRowClick: (rowData) => {
+      const getRowData = rowData[1].props.tableMeta.rowData
+      const reference = getRowData[1].split(delimiters.cell)[0];
+      const [chapter, verse] = reference.split(":");
+      const getUid = rowData[2].props.tableMeta.rowData
+      const [uid] = getUid[2].split(delimiters.cell)[1];
+      let rowId = `header-${chapter}-${verse}-${uid}`;
+      setSaveRowId(rowId)
+    },
+
+    onSearchClose: () =>{
+      const testRefId = saveRowId;
+      const element = document.getElementById(testRefId);
+      if ( element ) {
+        element.scrollIntoView();
+      } else {
+        alert(`Element id not found: ${testRefId}`);
+        // setPagination(false);
+      }
+    },
+
+    onFilterChipClose: () =>{
+      console.log('dsddddd')
+      const testRefId = saveRowId;
+      const element = document.getElementById(testRefId);
+      if ( element ) {
+        element.scrollIntoView();
+      } else {
+        alert(`Element id not found: ${testRefId}`);
+      }
+    },
+    onFilterDialogOpen:() =>{
+      console.log('dsddddd')
+      setPagination(false)
+    },
+    onSearchOpen:() =>{
+      console.log('dsddddd')
+      setPagination(false)
+    }
   };
 
   const rowHeader = (rowData, actionsMenu) => {

--- a/src/components/datatable/DataTable.md
+++ b/src/components/datatable/DataTable.md
@@ -23,47 +23,6 @@ function Component() {
     page: 0,
     rowsPerPage: 10,
     rowsPerPageOptions: [10, 25, 50, 100],
-    onRowClick: (rowData) => {
-      const getRowData = rowData[1].props.tableMeta.rowData
-      const [chapter] = getRowData[2].split(delimiters.cell);
-      const [verse] = getRowData[3].split(delimiters.cell);
-      const [uid] = getRowData[4].split(delimiters.cell);
-      const rowId = `header-${chapter}-${verse}-${uid}`;
-      setSaveRowId(rowId)
-    },
-
-    onSearchClose: () =>{
-      const testRefId = saveRowId;
-      if (testRefId){
-        const element = document.getElementById(testRefId);
-        if ( element ) {
-          element.scrollIntoView();
-        } else {
-          alert(`Element id not found: ${testRefId}`);
-        }
-      }
-      
-    },
-
-    onFilterChipClose: () =>{
-      const testRefId = saveRowId;
-      if (testRefId){
-        const element = document.getElementById(testRefId);
-        if ( element ) {
-          element.scrollIntoView();
-        } else {
-          alert(`Element id not found: ${testRefId}`);
-        }
-      }
-    },
-
-    onFilterDialogOpen:() =>{
-      setPagination(false)
-      
-    },
-    onSearchOpen:() =>{
-      setPagination(false)
-    },
   };
   
 

--- a/src/components/datatable/DataTable.md
+++ b/src/components/datatable/DataTable.md
@@ -4,97 +4,89 @@ import _sourceFile from "./mocks/en_tn_57-TIT";
 import targetFile from "./mocks/ru_tn_57-TIT";
 
 function Component() {
-  const [sourceFile, setSourceFile] = React.useState(_sourceFile);
-  const [savedFile, setSavedFile] = React.useState(targetFile);
-  
-  const [pagination, setPagination] = React.useState(true);
-  const [saveRowId, setSaveRowId] = React.useState('');
+    const [sourceFile, setSourceFile] = React.useState(_sourceFile);
+    const [savedFile, setSavedFile] = React.useState(targetFile);
 
+    //Uncomment this to test a page change from a new source file
+    // setTimeout(() => {
+    //   setSourceFile(targetFile);
+    // }, 5000)
 
-  //Uncomment this to test a page change from a new source file
-  // setTimeout(() => {
-  //   setSourceFile(targetFile);
-  // }, 5000)
+    const delimiters = { row: "\n", cell: "\t" };
 
-  const delimiters = { row: "\n", cell: "\t" };
-
-  const options = {
-    pagination: pagination,
-    page: 0,
-    rowsPerPage: 10,
-    rowsPerPageOptions: [10, 25, 50, 100],
-  };
-  
-
-  const rowHeader = (rowData, actionsMenu) => {
-    const book = rowData[0].split(delimiters.cell).find((value) => value);
-    const chapter = rowData[1].split(delimiters.cell).find((value) => value);
-    const verse = rowData[2].split(delimiters.cell).find((value) => value);
-    const styles = {
-      typography: {
-        lineHeight: "1.0",
-        fontWeight: "bold",
-      },
+    const options = {
+        page: 0,
+        rowsPerPage: 10,
+        rowsPerPageOptions: [10, 25, 50, 100],
     };
-    const component = (
-      <>
-        <Typography variant="h6" style={styles.typography}>
-          {`${book} ${chapter}:${verse}`}
-        </Typography>
-        {actionsMenu}
-      </>
+
+    const rowHeader = (rowData, actionsMenu) => {
+        const book = rowData[0].split(delimiters.cell).find((value) => value);
+        const chapter = rowData[1].split(delimiters.cell).find((value) => value);
+        const verse = rowData[2].split(delimiters.cell).find((value) => value);
+        const styles = {
+            typography: {
+                lineHeight: "1.0",
+                fontWeight: "bold",
+            },
+        };
+        const component = (
+            <>
+                <Typography variant="h6" style={styles.typography}>
+                    {`${book} ${chapter}:${verse}`}
+                </Typography>
+                {actionsMenu}
+            </>
+        );
+        return component;
+    };
+
+    const config = {
+        compositeKeyIndices: [0, 1, 2, 3],
+        columnsFilter: ["Chapter", "SupportReference"],
+        columnsShowDefault: [
+            "SupportReference",
+            "OrigQuote",
+            "Occurrence",
+            "OccurrenceNote",
+        ],
+        rowHeader,
+    };
+
+    const onSave = (_savedFile) => {
+        setSavedFile(_savedFile);
+        alert(_savedFile);
+    };
+
+    const onEdit = (content) => {
+        console.log("onEdit: Autosave...");
+        console.log({content});
+    };
+
+    const onValidate = () => {
+        alert("Validate!")
+    };
+
+    const generateRowId = (rowData) => {
+        const [chapter] = rowData[2].split(delimiters.cell);
+        const [verse] = rowData[3].split(delimiters.cell);
+        const [uid] = rowData[4].split(delimiters.cell);
+        return `header-${chapter}-${verse}-${uid}`;
+    };
+
+    return (
+        <DataTableWrapper
+            sourceFile={sourceFile}
+            targetFile={savedFile}
+            onSave={onSave}
+            onEdit={onEdit}
+            onValidate={onValidate}
+            delimiters={delimiters}
+            config={config}
+            options={options}
+            generateRowId={generateRowId}
+        />
     );
-    return component;
-  };
-
-  const config = {
-    compositeKeyIndices: [0, 1, 2, 3],
-    columnsFilter: ["Chapter", "SupportReference"],
-    columnsShowDefault: [
-      "SupportReference",
-      "OrigQuote",
-      "Occurrence",
-      "OccurrenceNote",
-    ],
-    rowHeader,
-  };
-
-  const onSave = (_savedFile) => {
-    setSavedFile(_savedFile);
-    alert(_savedFile);
-  };
-
-  const onEdit = (content) => {
-    console.log("onEdit: Autosave...");
-    // console.log({content});
-  };
-
-  const onValidate = () => {
-    alert("Validate!")
-  };
-
-  const generateRowId = (rowData) => {
-
-    const [chapter] = rowData[2].split(delimiters.cell);
-    const [verse] = rowData[3].split(delimiters.cell);
-    const [uid] = rowData[4].split(delimiters.cell);
-    const rowId = `header-${chapter}-${verse}-${uid}`;
-    return rowId;
-  };
-
-  return (
-    <DataTableWrapper
-      sourceFile={sourceFile}
-      targetFile={savedFile}
-      onSave={onSave}
-      onEdit={onEdit}
-      onValidate={onValidate}
-      delimiters={delimiters}
-      config={config}
-      options={options}
-      generateRowId={generateRowId}
-    />
-  );
 }
 <Component />;
 ```
@@ -118,9 +110,6 @@ function Component() {
   const [sourceFile, setSourceFile] = React.useState(_sourceFile);
   const [savedFile, setSavedFile] = React.useState(targetFile);
 
-  const [pagination, setPagination] = React.useState(true);
-  const [saveRowId, setSaveRowId] = React.useState('');
-
   //Uncomment this to test a page change from a new source file
   // setTimeout(() => {
   //   setSourceFile(targetFile);
@@ -129,46 +118,9 @@ function Component() {
   const delimiters = { row: "\n", cell: "\t" };
 
   const options = {
-    pagination: pagination,
     page: 0,
     rowsPerPage: 10,
     rowsPerPageOptions: [10, 25, 50, 100],
-    onRowClick: (rowData) => {
-      const getRowData = rowData[1].props.tableMeta.rowData
-      const reference = getRowData[1].split(delimiters.cell)[0];
-      const [chapter, verse] = reference.split(":");
-      const getUid = rowData[2].props.tableMeta.rowData
-      const [uid] = getUid[2].split(delimiters.cell)[1];
-      let rowId = `header-${chapter}-${verse}-${uid}`;
-      setSaveRowId(rowId)
-    },
-
-    onSearchClose: () =>{
-      const testRefId = saveRowId;
-      const element = document.getElementById(testRefId);
-      if ( element ) {
-        element.scrollIntoView();
-      } else {
-        alert(`Element id not found: ${testRefId}`);
-        // setPagination(false);
-      }
-    },
-
-    onFilterChipClose: () =>{
-      const testRefId = saveRowId;
-      const element = document.getElementById(testRefId);
-      if ( element ) {
-        element.scrollIntoView();
-      } else {
-        alert(`Element id not found: ${testRefId}`);
-      }
-    },
-    onFilterDialogOpen:() =>{
-      setPagination(false)
-    },
-    onSearchOpen:() =>{
-      setPagination(false)
-    }
   };
 
   const rowHeader = (rowData, actionsMenu) => {

--- a/src/components/datatable/DataTable.md
+++ b/src/components/datatable/DataTable.md
@@ -34,22 +34,26 @@ function Component() {
 
     onSearchClose: () =>{
       const testRefId = saveRowId;
-      const element = document.getElementById(testRefId);
-      if ( element ) {
-        element.scrollIntoView();
-      } else {
-        alert(`Element id not found: ${testRefId}`);
+      if (testRefId){
+        const element = document.getElementById(testRefId);
+        if ( element ) {
+          element.scrollIntoView();
+        } else {
+          alert(`Element id not found: ${testRefId}`);
+        }
       }
+      
     },
 
     onFilterChipClose: () =>{
-      console.log('dsddddd')
       const testRefId = saveRowId;
-      const element = document.getElementById(testRefId);
-      if ( element ) {
-        element.scrollIntoView();
-      } else {
-        alert(`Element id not found: ${testRefId}`);
+      if (testRefId){
+        const element = document.getElementById(testRefId);
+        if ( element ) {
+          element.scrollIntoView();
+        } else {
+          alert(`Element id not found: ${testRefId}`);
+        }
       }
     },
 
@@ -103,7 +107,7 @@ function Component() {
 
   const onEdit = (content) => {
     console.log("onEdit: Autosave...");
-    console.log({content});
+    // console.log({content});
   };
 
   const onValidate = () => {
@@ -192,7 +196,6 @@ function Component() {
     },
 
     onFilterChipClose: () =>{
-      console.log('dsddddd')
       const testRefId = saveRowId;
       const element = document.getElementById(testRefId);
       if ( element ) {
@@ -202,11 +205,9 @@ function Component() {
       }
     },
     onFilterDialogOpen:() =>{
-      console.log('dsddddd')
       setPagination(false)
     },
     onSearchOpen:() =>{
-      console.log('dsddddd')
       setPagination(false)
     }
   };


### PR DESCRIPTION
Closes #1088, #1089
Replaces PR #105 

* return to the last clicked row when closing the search.
* return to the last clicked row when closing or resetting the filter.

This will work even if the last clicked element is not on page one.
We save the index of the item in the whole data set. Calculate the page the element is on, change to the correct page, then scroll to the element. 
