### PR TITLE
Strip out nbsp on blur

### DIFF
--- a/src/components/cell/Cell.js
+++ b/src/components/cell/Cell.js
@@ -18,6 +18,7 @@ const inputFilters = [
 // screen to memory and thus to file
 const outputFilters = [
   [/^\u200B/,''], [/\u200B$/,''],
+  [/^\u00A0/,''], [/\u00A0$/,''],
   [/<br>/gi, '\n'],
   ['\n\n> ', '\\n\\n> '],
 ];


### PR DESCRIPTION
This fixes https://github.com/unfoldingWord/tc-create-app/issues/1354

Test in styleguidest:
* Add new row
* Click in OrigQuote field
* Notice by moving the cursor there is a space already in the field
* Add some text before the space
* Click off field
* Click back on field
* Notice space is now gone