### PR TITLE
Performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datatable-translatable",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "license": "MIT",
   "description": "A Component Library for Translating DataTables using React and MaterialUI.",
   "homepage": "https://datatable-translatable.netlify.com/",

--- a/src/components/cell/Cell.js
+++ b/src/components/cell/Cell.js
@@ -33,10 +33,8 @@ function BlockEditableWrapper({
   handleEdit,
   dataTestId,
   columnsFilterOptions,
-  originalFontFamily,
-  translationFontFamily,
 }) {
-  const classes = useStyles({ originalFontFamily, translationFontFamily });
+  const classes = useStyles();
   const subheading = (
     <Typography className={classes.subheading} variant='subtitle2' align='left' color='textSecondary'>
       {columnData.name}
@@ -134,10 +132,7 @@ function Cell(props) {
     delimiters,
     columnsFilterOptions,
     generateRowId = () => {},
-    originalFontFamily,
-    translationFontFamily,
   } = props;
-  const classes = useStyles();
   const [original, translation] = value.split(delimiters.cell);
 
   function handleEdit(markdown){
@@ -149,7 +144,7 @@ function Cell(props) {
   }
 
   return (
-    <div className={`cell-${rowIndex}-${columnIndex} ` + classes.root}>
+    <div className={`cell-${rowIndex}-${columnIndex} `}>
       <BlockEditableWrapper
         columnData={columnData}
         original={original}
@@ -160,8 +155,6 @@ function Cell(props) {
         handleEdit={handleEdit}
         dataTestId = {generateRowId(rowData)}
         columnsFilterOptions={columnsFilterOptions}
-        originalFontFamily={originalFontFamily}
-        translationFontFamily={translationFontFamily}
       />
     </div>
   );
@@ -172,8 +165,6 @@ Cell.propTypes = {
   value: PropTypes.string.isRequired,
   /** The tableMeta passed from MUIDataTables */
   tableMeta: PropTypes.object.isRequired,
-  /** The function to render the rowHeader */
-  rowHeader: PropTypes.func,
   /** Set html preview mode, false renders raw markdown */
   preview: PropTypes.bool,
   /** The delimiters for converting the file into rows/columns */

--- a/src/components/cell/styles.js
+++ b/src/components/cell/styles.js
@@ -1,21 +1,20 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(theme => ({
-  root: {},
-  original: props => ({
+const useStyles = makeStyles({
+  original: {
     padding: '0 8px',
     background: '#eee4',
     display: 'table-cell',
     width: '50%',
-    fontFamily: props.originalFontFamily || 'inherit',
-  }),
-  translation: props => ({
+    fontFamily: 'var(--datatable-original-font-family, inherit)',
+  },
+  translation: {
     padding: '0 15px',
     background: '#eee4',
     display: 'table-cell',
     width: '50%',
-    fontFamily: props.translationFontFamily || 'inherit',
-  }),
+    fontFamily: 'var(--datatable-translation-font-family, inherit)',
+  },
   subheading: {
     fontSize: '0.8em',
     fontStyle: 'italic',
@@ -37,31 +36,25 @@ const useStyles = makeStyles(theme => ({
   gridOriginal: {
     marginTop:'-15px',
     marginLeft:'2px',
-    padding: '15px 10px 0px 28px'
+    padding: '15px 10px 0px 28px',
   },
   divRow: {
-    display: 'table-row',
-    width: '100%',
+    'display': 'table-row',
+    'width': '100%',
     '& .editableWrapper': {
       marginTop:'-1em',
       marginLeft:'2px',
       display: 'table-cell',
-      width:'100%'
-    }
+      width:'100%',
+    },
   },
   divSubheading: {
     display: 'table-cell',
-    minWidth: '7em'
+    minWidth: '7em',
   },
-  divOccurrence: {
-    marginTop: '1em',
-    '& .editableWrapper': {
-      // marginTop: '1em'
-    }
-  },
-  divTranslation: {
-    marginTop: '1em'
-  }
-}));
+  divOccurrence: { marginTop: '1em' },
+  divTranslation: { marginTop: '1em' },
+});
+
 
 export default useStyles;

--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -233,12 +233,14 @@ function DataTable({
     columnNames, columnsFilter, columnsFilterOptions,
     columnsShow, delimiters, rowHeader,
     generateRowId, cellEdit, preview,
-    originalFontFamily, translationFontFamily,columnsMap,
-  }), [cellEdit, columnNames, columnsFilter, columnsFilterOptions, columnsShow, delimiters, generateRowId, preview, rowHeader, originalFontFamily, translationFontFamily, columnsMap]);
+    columnsMap,
+  }), [cellEdit, columnNames, columnsFilter, columnsFilterOptions, columnsShow, delimiters, generateRowId, preview, rowHeader, columnsMap]);
 
   return (
     <MuiThemeProvider theme={getMuiTheme}>
-      <DatatableMemo dataTableElement={dataTableElement} columns={[...columns, ...extraColumns]} data={_data} options={_options} {...props} />
+      <div style={ { '--datatable-original-font-family': originalFontFamily, '--datatable-translation-font-family': translationFontFamily } }>
+        <DatatableMemo dataTableElement={dataTableElement} columns={[...columns, ...extraColumns]} data={_data} options={_options} {...props} />
+      </div>
     </MuiThemeProvider>
   );
 }

--- a/src/components/datatable/DataTable.md
+++ b/src/components/datatable/DataTable.md
@@ -85,6 +85,8 @@ function Component() {
             config={config}
             options={options}
             generateRowId={generateRowId}
+            originalFontFamily="helvetica"
+            translationFontFamily="z003"
         />
     );
 }

--- a/src/components/datatable/helpers.js
+++ b/src/components/datatable/helpers.js
@@ -7,7 +7,6 @@ export function getColumns({
   columnNames, columnsFilter, columnsFilterOptions, columnsMap = {},
   columnsShow, delimiters, rowHeader,
   generateRowId, cellEdit, preview,
-  originalFontFamily, translationFontFamily,
 }) {
   let columns = columnNames.map((_name) => {
     const name = _name?.trim();
@@ -41,7 +40,7 @@ export function getColumns({
           const { tableState = {} } = tableMeta;
           const { rowsPerPage, page } = tableState || {};
           const cellProps = {
-            generateRowId, value, tableMeta, onEdit: cellEdit, delimiters, rowsPerPage, page, preview, columnsFilterOptions, originalFontFamily, translationFontFamily,
+            generateRowId, value, tableMeta, onEdit: cellEdit, delimiters, rowsPerPage, page, preview, columnsFilterOptions,
           };
           return <Cell {...cellProps} />;
         },

--- a/src/core/datatable.js
+++ b/src/core/datatable.js
@@ -170,20 +170,20 @@ export const getColumnsFilterOptions = ({
       values.forEach(value => {
         if (value) {
           if (!_columnsFilterOptions[columnIndex]) {
-            _columnsFilterOptions[columnIndex] = [];
+            _columnsFilterOptions[columnIndex] = new Set();
           }
 
-          if (!_columnsFilterOptions[columnIndex].includes(value)) {
-            _columnsFilterOptions[columnIndex].push(value);
+          if (!_columnsFilterOptions[columnIndex].has(value)) {
+            _columnsFilterOptions[columnIndex].add(value);
           }
         }
       });
-
-      if (_columnsFilterOptions[columnIndex]) {
-        _columnsFilterOptions[columnIndex].sort(); // sort SupportReference
-        _columnsFilterOptions[columnIndex].sort(sortSKU); // sort chapters and verses
-      }
     });
+  });
+  columnIndices.forEach(columnIndex => {
+    if (_columnsFilterOptions[columnIndex]) {
+      _columnsFilterOptions[columnIndex] = [..._columnsFilterOptions[columnIndex]].sort(sortSKU);// sort chapters and verses
+    }
   });
   return _columnsFilterOptions;
 };


### PR DESCRIPTION
Refactored to use a css var instead of a prop for the fontFamiles. Using a prop in makeStyles creates a separate style tag for each cell. Using a css var was noticeably faster but did not fix the real performance problem. 

the real problem was with getColumnsFilterOptions() which would filter the options every time after it added a new option. This was terribly inefficient and it always worked this way. It made noticeable performance problems with the changes in #119 because the sorting formula was a little more complex. 

Sorting all options after each one is added is 10x more efficient. 

Also uses a Set instead of array because set.has() is O(1) but array.includes() is O(n).