### PR TITLE
Fix empty ref in new row with LEV, JOS, or NUM

### DIFF
--- a/src/core/datatable.js
+++ b/src/core/datatable.js
@@ -91,7 +91,7 @@ export const rowGenerate = ({
     const column = columnNames[index];
     const values = Object.keys(rowsIndex[column]).length;
     const valuesRatio = values / rowCount;
-    const duplicateValue = (valuesRatio < 0.5);
+    const duplicateValue = (valuesRatio < 0.65); // If the value is reused many times then it should be duplicated.
 
     const valuesLengths = Object.keys(lengthIndex[column]);
     const valuesLengthsLength = valuesLengths.length;


### PR DESCRIPTION
Increase ratio value so only the very unique values will not be duplicated

The ratio is how many unique values to row count. It was expected that there would be an average of 2 notes for each verse but in some books there is not so the reference field is empty when creating new verse. Bumping the ration slightly fixes it. 

#fixes https://github.com/unfoldingWord/tc-create-app/issues/1533

To test:
* Use yalc to publish and use with tc-create-app
* Open TN, and book LEV, JOS or NUM
* Click `+` to add new row. 
* Reference should be populated.