### PR TITLE
enabled the save icon when removing the row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datatable-translatable",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "license": "MIT",
   "description": "A Component Library for Translating DataTables using React and MaterialUI.",
   "homepage": "https://datatable-translatable.netlify.com/",

--- a/src/components/actions-menu/DeleteRow.js
+++ b/src/components/actions-menu/DeleteRow.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import isEqual from 'lodash.isequal';
 import {
   Button,
@@ -12,6 +12,7 @@ import {
 import {
 } from '@material-ui/icons';
 import { getRowElement, getOffset } from '../../core/datatable';
+import { MarkdownContext } from 'markdown-translatable';
 
 function DeleteRowMenu({
   rowData,
@@ -22,6 +23,8 @@ function DeleteRowMenu({
   button,
   generateRowId,
 }) {
+  const { actions } = useContext(MarkdownContext);
+
   const [open, setOpen] = useState(false);
 
   const handleOpen = () => setOpen(true);
@@ -37,6 +40,11 @@ function DeleteRowMenu({
     const rowAbove = getRowElement(generateRowId, rowData, position);
     rowDelete({ rowIndex });
     handleClose();
+
+    if (actions && actions.setIsChanged) {
+      actions.setIsChanged(true);
+    }
+
     setTimeout(() => {
       if (rowAbove) {
         const top = getOffset(rowAbove).top;


### PR DESCRIPTION
## Describe what your pull request addresses:
-In tC create when we remove a row it does not make any changes in the file. It's also not enabling the save icon. The PR helps to enable the save icon when removing a row

### Test instructions for the pull request:
- Open PR link - https://deploy-preview-140--datatable-translatable.netlify.app/#/DataTableWrapper
- Go to the second-row TIT 1:1
- Click on the delete row icon (-) from the row header
![image](https://github.com/unfoldingWord/datatable-translatable/assets/25791348/34bbb998-402c-4091-bf88-f8b771ddd19b)
- Click the delete button in the pop-up window
![image](https://github.com/unfoldingWord/datatable-translatable/assets/25791348/854058b0-1883-4aa2-a7a8-bf839500b69a)
- Once the row is deleted you can see the save icon is enabled
![image](https://github.com/unfoldingWord/datatable-translatable/assets/25791348/0998a718-bbe3-4bd7-83d1-3c8bd0b478f1)



