### PR TITLE
Added prop to set default values to new rows

### DIFF
--- a/src/components/actions-menu/AddRow.js
+++ b/src/components/actions-menu/AddRow.js
@@ -33,7 +33,7 @@ function AddRowMenu({
   const [newRow, setNewRow] = useState();
   const { state } = useContext(DataTableContext);
   // console.log('Datatable Context state:', state);
-  const { data } = state;
+  const { data, newRowDefaultValues } = state;
   const { actions } = useContext(MarkdownContext);
 
 
@@ -134,11 +134,15 @@ function AddRowMenu({
             onChange={(event) => {
               newRow[i] = event.target.value;
             }}
+            data-test-id={`add-row-input-${name}`}
             fullWidth
           />
         );
 
-        if ( state.columnsFilterOptions[i] && state.columnsFilterOptions[i].length > 0 ) {
+        if (state.columnsFilterOptions[i] && state.columnsFilterOptions[i].length > 0) {
+          if (typeof newRowDefaultValues?.[name] === 'string') {
+            newRow[i] = newRowDefaultValues[name];
+          }
           text = (
             <Autocomplete
               key={i}
@@ -150,6 +154,7 @@ function AddRowMenu({
               onInputChange={(event, newValue) => {
                 newRow[i] = newValue;
               }}
+              data-test-id={`add-row-autocomplete-${name}`}
               renderInput={(params) => <TextField {...params} label={name} margin="normal" />}
               freeSolo={true}
             />

--- a/src/components/datatable/DataTable.context.js
+++ b/src/components/datatable/DataTable.context.js
@@ -22,6 +22,7 @@ export function DataTableContextProvider({
   config: {
     compositeKeyIndices,
     columnsFilter,
+    newRowDefaultValues,
   },
 }) {
   const [data, setData] = useState({});
@@ -175,6 +176,7 @@ export function DataTableContextProvider({
       data,
       changed,
       columnsFilterOptions,
+      newRowDefaultValues,
     },
     actions,
   }), [actions, changed, columnNames, columnsFilterOptions, data]);

--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -418,6 +418,15 @@ DataTable.propTypes = {
      * `rowHeader(rowData) => React Component`
      */
     rowHeader: PropTypes.func,
+    /** Object to override new row values 
+     * @example
+     * {
+     *   "id": "1",
+     *   "supportReference": "",
+     *   "occurrence": "2"
+     * }
+    */
+    newRowDefaultValues: PropTypes.objectOf(PropTypes.string),
   }).isRequired,
   /** Object to override columns settings */
   columnsMap: PropTypes.object,

--- a/src/components/datatable/DataTable.md
+++ b/src/components/datatable/DataTable.md
@@ -50,6 +50,9 @@ function Component() {
       "Occurrence",
       "OccurrenceNote",
     ],
+    newRowDefaultValues: {
+      SupportReference: ""
+    },
     rowHeader,
   };
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Allows users of this RCL to set default values to the "Add new row" form.

#### Please include detailed Test instructions for your pull request:
- Run yarn install and yarn start to open the styleguidist or open it from the  [deploy-preview](https://deploy-preview-149--datatable-translatable.netlify.app/).
- The first datatable example contains a table for translationNotes of Titus, click the add row button (+) on any existing row that contains a support reference.
- the newRowDefaultValues prop has been set so SupportReference value is empty so the "Add new row" form should show an empty support reference by default.
- try the same steps in the current https://datatable-translatable.netlify.app/
- the SupporReference field from the "Add new row" form would be prefilled with the same value as the row from which you have clicked the add row button.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
